### PR TITLE
redirect variable bug for signin

### DIFF
--- a/userena/utils.py
+++ b/userena/utils.py
@@ -72,7 +72,7 @@ def signin_redirect(redirect=None, user=None):
     :return: String containing the URI to redirect to.
 
     """
-    if redirect is not None: return redirect
+    if redirect: return redirect
     elif user is not None:
         return userena_settings.USERENA_SIGNIN_REDIRECT_URL % \
                 {'username': user.username}


### PR DESCRIPTION
Hi again,

I've hit a bug with the signin view: when signin_redirect (from utils.py) is called, sometimes the redirect variable is set to "", which let the "if redirect is not None" test pass. To prevent this, I've changed the test so that it now means "if it's None or if it's an empty string".

Cheers,

Guillaume
