### PR TITLE
just a 's'

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -81,7 +81,7 @@ Django's default backend, adding django-guardian and that of userena will get
 the following::
 
     AUTHENTICATION_BACKENDS = (
-        'userena.UserenaAuthenticationBackend',
+        'userena.backends.UserenaAuthenticationBackend',
         'guardian.backends.ObjectPermissionBackend',
         'django.contrib.auth.backends.ModelBackend',
     )


### PR DESCRIPTION
just a 's' added to avoid "Error: No module named easy_thumbnail"
