### PR TITLE
Passing "account" context to profile_form.html

### DIFF
--- a/userena/views.py
+++ b/userena/views.py
@@ -504,7 +504,7 @@ def profile_edit(request, username, edit_profile_form=EditProfileForm,
 
     if not extra_context: extra_context = dict()
     extra_context['form'] = form
-    extra_context['user'] = user
+    extra_context['account'] = {'user': user}
     return direct_to_template(request,
                               template_name,
                               extra_context=extra_context)


### PR DESCRIPTION
In the template "profile_form.html" the account context is used, but atm "user" is passed to the template. This is normally used for the currently logged-in user.
