### PR TITLE
Fixed the regular expression to actually exclude signout|signup|signin, instead of usernames that start with the characters 'signoutp'.

### DIFF
--- a/userena/urls.py
+++ b/userena/urls.py
@@ -87,7 +87,7 @@ urlpatterns = patterns('',
        name='userena_profile_edit'),
 
     # View profiles
-    url(r'^(?P<username>(?![signout|signup|signin])[\.\w]+)/$',
+    url(r'^(?P<username>(?!signout|signup|signin)[\.\w]+)/$',
        userena_views.profile_detail,
        name='userena_profile_detail'),
     url(r'^page/(?P<page>[0-9]+)/$',


### PR DESCRIPTION
Fixed the regular expression to actually exclude signout|signup|signin, instead of usernames that start with the characters 'signoutp'.
