### PR TITLE
Add divs around default template content to make it more customizable

### DIFF
--- a/userena/templates/userena/activate_fail.html
+++ b/userena/templates/userena/activate_fail.html
@@ -5,6 +5,10 @@
 {% block content_title %}<h2>{% trans "Your account could not be activated.." %}</h2>{% endblock %}
 
 {% block content %}
-<p>{% trans "Your account could not be activated. This could be because your activation link has aged." %}</p>
-<p>{% trans "Please try signing up again or contact us if you think something went wrong." %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% trans "Your account could not be activated. This could be because your activation link has aged." %}</p>
+        <p>{% trans "Please try signing up again or contact us if you think something went wrong." %}</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/disabled.html
+++ b/userena/templates/userena/disabled.html
@@ -4,6 +4,10 @@
 {% block title %}{% trans "Disabled account" %}{% endblock %}
 {% block content_title %}<h2>{% trans "Your account has been disabled" %}</h2>{% endblock %}
 {% block content %}
-<p>{% trans "It seems your account has been disabled." %}</p>
-<p>{% trans "If you feel that injustice has been done to you, feel free to contact the administrators to find out why" %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% trans "It seems your account has been disabled." %}</p>
+        <p>{% trans "If you feel that injustice has been done to you, feel free to contact the administrators to find out why" %}</p>
+    </div>
+</div>
 {% endblock %} 

--- a/userena/templates/userena/email_change_complete.html
+++ b/userena/templates/userena/email_change_complete.html
@@ -5,6 +5,10 @@
 {% block content_title %}<h2>{% trans 'Confirm your new email' %}</h2>{% endblock %}
 
 {% block content %}
-<p>{% blocktrans with viewed_user.email_unconfirmed as email %}You have received an email at {{ email }}.{% endblocktrans %}</p>
-<p>{% blocktrans with viewed_user.username as username %}To associate this email address with your account ({{ username }}) click on the link provided in this email.{% endblocktrans %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% blocktrans with viewed_user.email_unconfirmed as email %}You have received an email at {{ email }}.{% endblocktrans %}</p>
+        <p>{% blocktrans with viewed_user.username as username %}To associate this email address with your account ({{ username }}) click on the link provided in this email.{% endblocktrans %}</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/email_confirm_complete.html
+++ b/userena/templates/userena/email_confirm_complete.html
@@ -5,5 +5,9 @@
 
 {% block content_title %}<h2>{% trans 'New email' %}</h2>{% endblock %}
 {% block content %}
-<p>{% blocktrans %}Your new email address is saved. You can continue using userena with this email.{% endblocktrans %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% blocktrans %}Your new email address is saved. You can continue using userena with this email.{% endblocktrans %}</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/email_confirm_fail.html
+++ b/userena/templates/userena/email_confirm_fail.html
@@ -5,6 +5,10 @@
 {% block content_title %}<h2>{% trans "Your email could not be verified.." %}</h2>{% endblock %}
 
 {% block content %}
-<p>{% trans "Your email could not be verified..." %}</p>
-<p>{% trans "You could try changing it again in your account settings." %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% trans "Your email could not be verified..." %}</p>
+        <p>{% trans "You could try changing it again in your account settings." %}</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/email_form.html
+++ b/userena/templates/userena/email_form.html
@@ -4,18 +4,22 @@
 {% block content_title %}<h2>{% blocktrans with user.username as username %}Account &raquo; {{ username }}{% endblocktrans %}</h2>{% endblock %}
 
 {% block content %}
-<form action="" method="post">
-  <ul id="box-nav">
-    <li class="first"><a href="{% url userena_profile_detail user.username %}"><span>{% trans 'View profile' %}</span></a></li>
-    <li><a href="{% url userena_profile_edit user.username %}">{% trans "Edit profile" %}</a></li>
-    <li><a href="{% url userena_password_change user.username %}">{% trans "Change password" %}</a></li>
-    <li class="last selected"><a href="{% url userena_email_change user.username %}">{% trans "Change email" %}</a></li>
-  </ul>
-  {% csrf_token %}
-  <fieldset>
-    <legend>{% trans "Change email address" %}</legend>
-    {{ form.as_p }}
-  </fieldset>
-  <input type="submit" value="{% trans "Change email" %}" />
-</form>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <form action="" method="post">
+          <ul id="box-nav">
+            <li class="first"><a href="{% url userena_profile_detail user.username %}"><span>{% trans 'View profile' %}</span></a></li>
+            <li><a href="{% url userena_profile_edit user.username %}">{% trans "Edit profile" %}</a></li>
+            <li><a href="{% url userena_password_change user.username %}">{% trans "Change password" %}</a></li>
+            <li class="last selected"><a href="{% url userena_email_change user.username %}">{% trans "Change email" %}</a></li>
+          </ul>
+          {% csrf_token %}
+          <fieldset>
+            <legend>{% trans "Change email address" %}</legend>
+            {{ form.as_p }}
+          </fieldset>
+          <input type="submit" value="{% trans "Change email" %}" />
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/password_complete.html
+++ b/userena/templates/userena/password_complete.html
@@ -5,5 +5,9 @@
 {% block content_title %}<h2>{% trans "Your password has been changed" %}.</h2>{% endblock %}
 
 {% block content %}
-<p>{% trans "From now on you can use your new password to signin" %}.</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% trans "From now on you can use your new password to signin" %}.</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/password_form.html
+++ b/userena/templates/userena/password_form.html
@@ -6,18 +6,22 @@
 {% block content_title %}<h2>{% blocktrans with user.username as username %}Account &raquo; {{ username }}{% endblocktrans %}</h2>{% endblock %}
 
 {% block content %}
-<form action="" method="post" id="password_change_form">
-  <ul id="box-nav">
-    <li class="first"><a href="{% url userena_profile_detail user.username %}"><span>{% trans 'View profile' %}</span></a></li>
-    <li><a href="{% url userena_profile_edit user.username %}">{% trans "Edit profile" %}</a></li>
-    <li  class="selected"><a href="{% url userena_password_change user.username %}">{% trans "Change password" %}</a></li>
-    <li class="last"><a href="{% url userena_email_change user.username %}">{% trans "Change email" %}</a></li>
-  </ul>
-  <fieldset>
-    <legend>{% trans "Change Password" %}</legend>
-    {% csrf_token %}
-    {{ form.as_p }}
-  </fieldset>
-  <input type="submit" value="{% trans "Change password" %}" />
-</form>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <form action="" method="post" id="password_change_form">
+          <ul id="box-nav">
+            <li class="first"><a href="{% url userena_profile_detail user.username %}"><span>{% trans 'View profile' %}</span></a></li>
+            <li><a href="{% url userena_profile_edit user.username %}">{% trans "Edit profile" %}</a></li>
+            <li  class="selected"><a href="{% url userena_password_change user.username %}">{% trans "Change password" %}</a></li>
+            <li class="last"><a href="{% url userena_email_change user.username %}">{% trans "Change email" %}</a></li>
+          </ul>
+          <fieldset>
+            <legend>{% trans "Change Password" %}</legend>
+            {% csrf_token %}
+            {{ form.as_p }}
+          </fieldset>
+          <input type="submit" value="{% trans "Change password" %}" />
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/password_reset_complete.html
+++ b/userena/templates/userena/password_reset_complete.html
@@ -4,5 +4,9 @@
 {% block title %}{% trans "Password reset" %}{% endblock %}
 {% block content_title %}<h2>{% trans "Your password has been reset" %}</h2>{% endblock %}
 {% block content %}
-{% trans "You can now " %}<a href="{% url userena_signin %}">{% trans "signin" %}</a> {% trans "with your new password." %}
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        {% trans "You can now " %}<a href="{% url userena_signin %}">{% trans "signin" %}</a> {% trans "with your new password." %}
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/password_reset_confirm_form.html
+++ b/userena/templates/userena/password_reset_confirm_form.html
@@ -4,12 +4,16 @@
 {% block title %}{% trans "Reset password" %}{% endblock %}
 
 {% block content %}
-<form action="" method="post">
-  <fieldset>
-    <legend>{% trans "Reset Password" %}</legend>
-    {% csrf_token %}
-    {{ form.as_p }}
-  </fieldset>
-  <input type="submit" value="{% trans "Reset password" %}" />
-</form>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <form action="" method="post">
+          <fieldset>
+            <legend>{% trans "Reset Password" %}</legend>
+            {% csrf_token %}
+            {{ form.as_p }}
+          </fieldset>
+          <input type="submit" value="{% trans "Reset password" %}" />
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/password_reset_done.html
+++ b/userena/templates/userena/password_reset_done.html
@@ -5,5 +5,9 @@
 {% block content_title %}<h2>{% trans "Reset password email is send" %}</h2>{% endblock %}
 
 {% block content %}
-<p>{% trans "An e-mail has been send to you which explains how to reset your password." %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% trans "An e-mail has been send to you which explains how to reset your password." %}</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/password_reset_form.html
+++ b/userena/templates/userena/password_reset_form.html
@@ -4,12 +4,16 @@
 {% block title %}{% trans "Reset password" %}{% endblock %}
 
 {% block content %}
-<form action="" method="post">
-  <fieldset>
-    <legend>{% trans "Reset Password" %}</legend>
-    {% csrf_token %}
-    {{ form.as_p }}
-  </fieldset>
-  <input type="submit" value="{% trans "Send password" %}" />
-</form>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <form action="" method="post">
+          <fieldset>
+            <legend>{% trans "Reset Password" %}</legend>
+            {% csrf_token %}
+            {{ form.as_p }}
+          </fieldset>
+          <input type="submit" value="{% trans "Send password" %}" />
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/profile_detail.html
+++ b/userena/templates/userena/profile_detail.html
@@ -5,38 +5,42 @@
 {% block content_title %}<h2>{{ profile.user.username }} {% if profile.user.get_full_name %}({{ profile.user.get_full_name }}){% endif %}</h2>{% endblock %}
 
 {% block content %}
-<div class="white-box">
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <div class="white-box">
 
-  {% comment %}Dirty hack. Will use django-guardian in the future.{% endcomment %}
-  {% if user.username == profile.user.username %}
-  <ul id="box-nav">
-    <li><a href="{% url userena_profile_detail user.username %}">{% trans "View profile" %} &raquo;</a></li>
-    <li><a href="{% url userena_profile_edit user.username %}">{% trans "Edit details" %} &raquo;</a></li>
-    <li><a href="{% url userena_password_change user.username %}">{% trans "Change password" %} &raquo;</a></li>
-    <li><a href="{% url userena_email_change user.username %}">{% trans "Change email" %} &raquo;</a></li>
-  </ul>
-  {% endif %}
+          {% comment %}Dirty hack. Will use django-guardian in the future.{% endcomment %}
+          {% if user.username == profile.user.username %}
+          <ul id="box-nav">
+            <li><a href="{% url userena_profile_detail user.username %}">{% trans "View profile" %} &raquo;</a></li>
+            <li><a href="{% url userena_profile_edit user.username %}">{% trans "Edit details" %} &raquo;</a></li>
+            <li><a href="{% url userena_password_change user.username %}">{% trans "Change password" %} &raquo;</a></li>
+            <li><a href="{% url userena_email_change user.username %}">{% trans "Change email" %} &raquo;</a></li>
+          </ul>
+          {% endif %}
 
-  <div id="details">
-    <img src="{{ profile.get_mugshot_url }}" alt="{% trans "Your mugshot" %}" />
-    {% if profile.user.get_full_name %}
-    <p><strong>{% trans "Name" %}</strong><br /> {{ profile.user.get_full_name }}</p>
-    {% endif %}
-    {% if profile.user.email %}
-    <p><strong>{% trans "Email" %}</strong><br />{{ profile.user.email }}</p>
-    {% endif %}
-    {% if profile.age %}
-    <p><strong>{% trans "Age" %}</strong><br /> {{ profile.age }}</p>
-    {% endif %}
-    {% if profile.website %}
-    <p><strong>{% trans "Website" %}</strong><br /> <a href="{{ profile.website }}">{{ profile.website }}</a></p>
-    {% endif %}
-    {% if profile.location %}
-    <p><strong>{% trans "Location" %}</strong><br />{{ profile.location }}</p>
-    {% endif %}
-    {% if profile.about_me %}
-    <p><strong>{% trans "About me" %}</strong><br />{{ profile.about_me }}</p>
-    {% endif %}
-  </div>
+          <div id="details">
+            <img src="{{ profile.get_mugshot_url }}" alt="{% trans "Your mugshot" %}" />
+            {% if profile.user.get_full_name %}
+            <p><strong>{% trans "Name" %}</strong><br /> {{ profile.user.get_full_name }}</p>
+            {% endif %}
+            {% if profile.user.email %}
+            <p><strong>{% trans "Email" %}</strong><br />{{ profile.user.email }}</p>
+            {% endif %}
+            {% if profile.age %}
+            <p><strong>{% trans "Age" %}</strong><br /> {{ profile.age }}</p>
+            {% endif %}
+            {% if profile.website %}
+            <p><strong>{% trans "Website" %}</strong><br /> <a href="{{ profile.website }}">{{ profile.website }}</a></p>
+            {% endif %}
+            {% if profile.location %}
+            <p><strong>{% trans "Location" %}</strong><br />{{ profile.location }}</p>
+            {% endif %}
+            {% if profile.about_me %}
+            <p><strong>{% trans "About me" %}</strong><br />{{ profile.about_me }}</p>
+            {% endif %}
+          </div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/userena/templates/userena/profile_form.html
+++ b/userena/templates/userena/profile_form.html
@@ -6,19 +6,22 @@
 {% block content_title %}<h2>{% blocktrans with profile.user.username as username %}Account &raquo; {{ username }}{% endblocktrans %}</h2>{% endblock %}
 
 {% block content %}
-
-<form action="" enctype="multipart/form-data" method="post">
-  <ul id="box-nav">
-    <li class="first"><a href="{% url userena_profile_detail user.username %}"><span>{% trans 'View profile' %}</span></a></li>
-    <li class="selected"><a href="{% url userena_profile_edit user.username %}">{% trans "Edit profile" %}</a></li>
-    <li><a href="{% url userena_password_change user.username %}">{% trans "Change password" %}</a></li>
-    <li class="last"><a href="{% url userena_email_change user.username %}">{% trans "Change email" %}</a></li>
-  </ul>
-  {% csrf_token %}
-  <fieldset>
-    <legend>{% trans "Edit Profile" %}</legend>
-    {{ form.as_p }}
-  </fieldset>
-  <input type="submit" value="{% trans "Save changes" %}" />
-</form>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <form action="" enctype="multipart/form-data" method="post">
+          <ul id="box-nav">
+            <li class="first"><a href="{% url userena_profile_detail user.username %}"><span>{% trans 'View profile' %}</span></a></li>
+            <li class="selected"><a href="{% url userena_profile_edit user.username %}">{% trans "Edit profile" %}</a></li>
+            <li><a href="{% url userena_password_change user.username %}">{% trans "Change password" %}</a></li>
+            <li class="last"><a href="{% url userena_email_change user.username %}">{% trans "Change email" %}</a></li>
+          </ul>
+          {% csrf_token %}
+          <fieldset>
+            <legend>{% trans "Edit Profile" %}</legend>
+            {{ form.as_p }}
+          </fieldset>
+          <input type="submit" value="{% trans "Save changes" %}" />
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/profile_list.html
+++ b/userena/templates/userena/profile_list.html
@@ -4,33 +4,37 @@
 {% block content_title %}<h2>{% trans 'Profiles' %}</h2>{% endblock %}
 
 {% block content %}
-<ul id="profile_list">
-  {% for profile in profile_list %}
-  <li>
-  <a href="{% url userena_profile_detail profile.user.username %}"><img src="{{ profile.get_mugshot_url }}" /></a>
-  <a href="{% url userena_profile_detail profile.user.username %}">{{ profile.user.username }}</a>
-  </li>
-  {% endfor %}
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <ul id="profile_list">
+          {% for profile in profile_list %}
+          <li>
+          <a href="{% url userena_profile_detail profile.user.username %}"><img src="{{ profile.get_mugshot_url }}" /></a>
+          <a href="{% url userena_profile_detail profile.user.username %}">{{ profile.user.username }}</a>
+          </li>
+          {% endfor %}
 
-</ul>
+        </ul>
 
-{% if is_paginated %}
-<div class="pagination">
-  <span class="step-links">
-    {% if page_obj.has_previous %}
-    <a href="{% url userena_profile_list_paginated page_obj.previous_page_number %}">{% trans 'previous' %}</a>
-    {% endif %}
+        {% if is_paginated %}
+        <div class="pagination">
+          <span class="step-links">
+            {% if page_obj.has_previous %}
+            <a href="{% url userena_profile_list_paginated page_obj.previous_page_number %}">{% trans 'previous' %}</a>
+            {% endif %}
 
-    <span class="current">
-      {% blocktrans with page_obj.number as page and page_obj.paginator.num_pages as num_pages %}
-      Page {{ page }} of {{ num_pages }}
-      {% endblocktrans %}
-    </span>
+            <span class="current">
+              {% blocktrans with page_obj.number as page and page_obj.paginator.num_pages as num_pages %}
+              Page {{ page }} of {{ num_pages }}
+              {% endblocktrans %}
+            </span>
 
-    {% if page_obj.has_next %}
-    <a href="{% url userena_profile_list_paginated  page_obj.next_page_number %}">{% trans 'next' %}</a>
-    {% endif %}
-  </span>
+            {% if page_obj.has_next %}
+            <a href="{% url userena_profile_list_paginated  page_obj.next_page_number %}">{% trans 'next' %}</a>
+            {% endif %}
+          </span>
+        </div>
+        {% endif %}
+    </div>
 </div>
-{% endif %}
 {% endblock %}

--- a/userena/templates/userena/signin_form.html
+++ b/userena/templates/userena/signin_form.html
@@ -4,27 +4,31 @@
 {% block title %}{% trans "Signin" %}{% endblock %}
 
 {% block content %}
-<form action="" method="post">
-  {% csrf_token %}
-  <fieldset>
-    <legend>{% trans "Signin" %}</legend>
-    {{ form.non_field_errors }}
-    {% for field in form %}
-    {{ field.errors }}
-    {% comment %} Displaying checkboxes differently {% endcomment %}
-    {% if field.name == 'remember_me' %}
-    <p class="checkbox">
-    <label for="id_{{ field.name }}">{{ field }} {{ field.label }}</label>
-    </p>
-    {% else %}
-    <p>
-    {{ field.label_tag }} 
-    {{ field }}
-    </p>
-    {% endif %}
-    {% endfor %}
-  </fieldset>
-  <input type="submit" value="{% trans "Signin" %}" />
-  <p class="forgot-password"><a href="{% url userena_password_reset %}" title="{% trans "Forgot your password?" %}">{% trans "Forgot your password?" %}</a></p>
-</form>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <form action="" method="post">
+          {% csrf_token %}
+          <fieldset>
+            <legend>{% trans "Signin" %}</legend>
+            {{ form.non_field_errors }}
+            {% for field in form %}
+            {{ field.errors }}
+            {% comment %} Displaying checkboxes differently {% endcomment %}
+            {% if field.name == 'remember_me' %}
+            <p class="checkbox">
+            <label for="id_{{ field.name }}">{{ field }} {{ field.label }}</label>
+            </p>
+            {% else %}
+            <p>
+            {{ field.label_tag }} 
+            {{ field }}
+            </p>
+            {% endif %}
+            {% endfor %}
+          </fieldset>
+          <input type="submit" value="{% trans "Signin" %}" />
+          <p class="forgot-password"><a href="{% url userena_password_reset %}" title="{% trans "Forgot your password?" %}">{% trans "Forgot your password?" %}</a></p>
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/signout.html
+++ b/userena/templates/userena/signout.html
@@ -5,5 +5,9 @@
 {% block content_title %}<h2>{% trans "You have been signed out" %}.</h2>{% endblock %}
 
 {% block content %}
-<p>{% trans "You have been signed out. Till we meet again." %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% trans "You have been signed out. Till we meet again." %}</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/signup_complete.html
+++ b/userena/templates/userena/signup_complete.html
@@ -6,7 +6,11 @@
 {% block content_title %}<h2>{% trans "Signup" %}</h2>{% endblock %}
 
 {% block content %}
-<p>{% trans "Thank you for signing up with us!" %}</p>
-<p>{% blocktrans %}You have been send an e-mail with an activation link to the supplied email.{% endblocktrans %}</p>
-<p>{% blocktrans %}We will store your signup information for {{ userena_activation_days }} days on our server. {% endblocktrans %}</p>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <p>{% trans "Thank you for signing up with us!" %}</p>
+        <p>{% blocktrans %}You have been send an e-mail with an activation link to the supplied email.{% endblocktrans %}</p>
+        <p>{% blocktrans %}We will store your signup information for {{ userena_activation_days }} days on our server. {% endblocktrans %}</p>
+    </div>
+</div>
 {% endblock %}

--- a/userena/templates/userena/signup_form.html
+++ b/userena/templates/userena/signup_form.html
@@ -4,25 +4,29 @@
 {% block title %}{% trans "Signup" %}{% endblock %}
 
 {% block content %}
-<form action="" method="post">
-  {% csrf_token %}
-  <fieldset>
-    <legend>Signup</legend>
-    {% for field in form %}
-    {{ field.errors }}
-    {% comment %} Displaying checkboxes differently {% endcomment %}
-    {% if field.name == 'tos' %}
-    <p class="checkbox">
-    <label for="id_{{ field.name }}">{{ field }} {{ field.label }}</label>
-    </p>
-    {% else %}
-    <p>
-    {{ field.label_tag }} 
-    {{ field }}
-    </p>
-    {% endif %}
-    {% endfor %}
-  </fieldset>
-  <input type="submit" value="{% trans "Signup"%}" />
-</form>
+<div id="userena-content-wrapper">
+    <div id="userena-content">
+        <form action="" method="post">
+          {% csrf_token %}
+          <fieldset>
+            <legend>Signup</legend>
+            {% for field in form %}
+            {{ field.errors }}
+            {% comment %} Displaying checkboxes differently {% endcomment %}
+            {% if field.name == 'tos' %}
+            <p class="checkbox">
+            <label for="id_{{ field.name }}">{{ field }} {{ field.label }}</label>
+            </p>
+            {% else %}
+            <p>
+            {{ field.label_tag }} 
+            {{ field }}
+            </p>
+            {% endif %}
+            {% endfor %}
+          </fieldset>
+          <input type="submit" value="{% trans "Signup"%}" />
+        </form>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
I'm adding userena to an existing, already fairly heavy website design and I found it was a pain in the ass to customize the userena templates, because django has no mechanism to check if a block exists. This adds explicit div tags around all of the userena template content to allow for more customization.

I made this because I needed it, and I can see how others would as well. This doesn't change any default behavior (other than sending a few blank divs on the example) - but it makes it a lot easier for any developer looking to integrate userena with their design.

Pull if you think this is useful, or don't if you think this is the wrong approach.
