### PR TITLE
signup_complete.html template is broken due a break row

### DIFF
--- a/userena/templates/userena/signup_complete.html
+++ b/userena/templates/userena/signup_complete.html
@@ -10,8 +10,7 @@
 
 {% if userena_activation_required %}
 <p>{% blocktrans %}You have been send an e-mail with an activation link to the supplied email.{% endblocktrans %}</p>
-<p>{% blocktrans %}We will store your signup information for {{
-  userena_activation_days }} days on our server. {% endblocktrans %}</p>
+<p>{% blocktrans %}We will store your signup information for {{ userena_activation_days }} days on our server. {% endblocktrans %}</p>
 {% else  %}
 <p>{% blocktrans %}You can now use the supplied credentials to signin.{% endblocktrans %}</p>
 {% endif %}


### PR DESCRIPTION
Fix a useless break row in signup_complete.html template that broke translation and userena_activation_days variable to render.
