### PR TITLE
Past tense 'sent' instead of 'send'

### DIFF
--- a/userena/templates/userena/password_reset_done.html
+++ b/userena/templates/userena/password_reset_done.html
@@ -1,9 +1,9 @@
 {% extends 'userena/base_userena.html' %}
 {% load i18n %}
 
-{% block title %}{% trans "Reset password email is send" %}{% endblock %}
-{% block content_title %}<h2>{% trans "Reset password email is send" %}</h2>{% endblock %}
+{% block title %}{% trans "Password reset email sent" %}{% endblock %}
+{% block content_title %}<h2>{% trans "Password reset email sent" %}</h2>{% endblock %}
 
 {% block content %}
-<p>{% trans "An e-mail has been send to you which explains how to reset your password." %}</p>
+<p>{% trans "An e-mail has been sent to you which explains how to reset your password." %}</p>
 {% endblock %}


### PR DESCRIPTION
The past tense 'sent' should be used instead of 'send' for the password_reset_done template. 
