### PR TITLE
Can now change the crop 'type' on the thumbnail field for UserenaBaseProfile.

### DIFF
--- a/userena/models.py
+++ b/userena/models.py
@@ -205,7 +205,7 @@ class UserenaBaseProfile(models.Model):
 
     MUGSHOT_SETTINGS = {'size': (userena_settings.USERENA_MUGSHOT_SIZE,
                                  userena_settings.USERENA_MUGSHOT_SIZE),
-                        'crop': 'smart'}
+                        'crop': userena_settings.USERENA_MUGSHOT_CROP_TYPE}
 
     mugshot = ThumbnailerImageField(_('mugshot'),
                                     blank=True,

--- a/userena/settings.py
+++ b/userena/settings.py
@@ -63,6 +63,10 @@ USERENA_MUGSHOT_SIZE = getattr(settings,
                                'USERENA_MUGSHOT_SIZE',
                                80)
 
+USERENA_MUGSHOT_CROP_TYPE = getattr(settings,
+                                    'USERENA_MUGSHOT_CROP_TYPE',
+                                    'smart')
+
 USERENA_MUGSHOT_PATH = getattr(settings,
                                'USERENA_MUGSHOT_PATH',
                                'mugshots/')


### PR DESCRIPTION
...renaBaseProfile.  New setting added.

Added USERENA_MUGSHOT_CROP_TYPE (default value of 'smart'), which when the developer overrides it to 'scale' maintains the original uploaded image's aspect ratio.  Simple and small change.

Let me know if there are any questions or perhaps I missed this functionality in another way.
