### PR TITLE
Do not use usernames in email templates when usernames are disabled.

### DIFF
--- a/userena/models.py
+++ b/userena/models.py
@@ -118,6 +118,7 @@ class UserenaSignup(models.Model):
 
         """
         context= {'user': self.user,
+                  'without_usernames': userena_settings.USERENA_WITHOUT_USERNAMES,
                   'new_email': self.email_unconfirmed,
                   'protocol': get_protocol(),
                   'confirmation_key': self.email_confirmation_key,
@@ -179,6 +180,7 @@ class UserenaSignup(models.Model):
 
         """
         context= {'user': self.user,
+                  'without_usernames': userena_settings.USERENA_WITHOUT_USERNAMES,
                   'protocol': get_protocol(),
                   'activation_days': userena_settings.USERENA_ACTIVATION_DAYS,
                   'activation_key': self.activation_key,

--- a/userena/templates/userena/emails/activation_email_message.txt
+++ b/userena/templates/userena/emails/activation_email_message.txt
@@ -1,6 +1,6 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans with user.username as username %}Dear {{ username }},{% endblocktrans %}
-
+{% if not without_usernames %}{% blocktrans with user.username as username %}Dear {{ username }},{% endblocktrans %}
+{% endif %}
 {% blocktrans with site.name as site %}Thank you for signing up at {{ site }}.{% endblocktrans %}
 
 {% trans "To activate your account you should click on the link below:" %}

--- a/userena/templates/userena/emails/confirmation_email_message_new.txt
+++ b/userena/templates/userena/emails/confirmation_email_message_new.txt
@@ -1,6 +1,6 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans with user.username as username %}Dear {{ username }},{% endblocktrans %}
-
+{% if not without_usernames %}{% blocktrans with user.username as username %}Dear {{ username }},{% endblocktrans %}
+{% endif %}
 {% blocktrans with site.name as site %}You requested a change of your email address at {{ site }}.{% endblocktrans %}
 
 

--- a/userena/templates/userena/emails/confirmation_email_message_old.txt
+++ b/userena/templates/userena/emails/confirmation_email_message_old.txt
@@ -1,6 +1,6 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans with user.username as username %}Dear {{ username }},{% endblocktrans %}
-
+{% if not without_usernames %}{% blocktrans with user.username as username %}Dear {{ username }},{% endblocktrans %}
+{% endif %}
 {% blocktrans with site.name as site %}There was a request to change your email address at {{ site }}.{% endblocktrans %}
 
 {% blocktrans %}An email has been send to {{ new_email }} which contains a verification link. Click on the link in this email to activate it.{% endblocktrans %}

--- a/userena/templates/userena/emails/password_reset_message.txt
+++ b/userena/templates/userena/emails/password_reset_message.txt
@@ -7,10 +7,10 @@ for your user account at {{ site_name }}{% endblocktrans %}.
 {{ protocol }}://{{ domain }}{% url django.contrib.auth.views.password_reset_confirm uidb36=uid token=token %}
 {% endblock %}
 
-{% blocktrans with user.username as username %}
+{% if not without_usernames %}{% blocktrans with user.username as username %}
 Your username, in case you've forgotten: {{ username }}
 {% endblocktrans %}
-
+{% endif %}
 {% trans "Thanks for using our site!" %}
 
 {% trans "Sincerely" %},


### PR DESCRIPTION
The inverse "if" logic is a little funky. But I chose to match the settings values 1-for-1.
