### PR TITLE
Small tweak in template password_reset_message.txt

### DIFF
--- a/userena/templates/userena/emails/password_reset_message.txt
+++ b/userena/templates/userena/emails/password_reset_message.txt
@@ -4,7 +4,7 @@ for your user account at {{ site_name }}{% endblocktrans %}.
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-{{ protocol }}://{{ domain }}{% url django.contrib.auth.views.password_reset_confirm uidb36=uid token=token %}
+{{ protocol }}://{{ domain }}{% url userena_password_reset_confirm uidb36=uid token=token %}
 {% endblock %}
 
 {% if not without_usernames %}{% blocktrans with user.username as username %}


### PR DESCRIPTION
Better to use the view name instead of the view path. That way if you have a custom password_reset_confirm view, you can still name it 'userena_password_reset_confirm' in your urlconf, and don't need to override the template.
