### PR TITLE
Error when running unit tests

### DIFF
--- a/userena/tests/profiles/test.py
+++ b/userena/tests/profiles/test.py
@@ -8,7 +8,7 @@ class ProfileTestCase(test.TestCase):
     def _pre_setup(self):
         # Add the models to the db.
         self._original_installed_apps = list(settings.INSTALLED_APPS)
-        settings.INSTALLED_APPS.append('userena.tests.profiles')
+        settings.INSTALLED_APPS += ('userena.tests.profiles',)
         loading.cache.loaded = False
         call_command('syncdb', interactive=False, verbosity=0)
 


### PR DESCRIPTION
We should use += to append the test specific app in INSTALLED_APPS at runtime, not .append method.
