### PR TITLE
Provide the old email address in the confirmation_complete signal.

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -23,8 +23,10 @@ the ``user`` argument which Django's :class:`User` class.
 confirmation_complete
 ---------------------
 
-A user has succesfully changed their email. The signal provides you with
-the ``user`` argument which Django's :class:`User` class.
+A user has succesfully changed their email. The signal provides you
+with the ``user`` argument which Django's :class:`User` class, and the
+``old_email`` argument which is the user's old email address as a
+string.
 
 password_complete
 -----------------

--- a/userena/managers.py
+++ b/userena/managers.py
@@ -140,9 +140,10 @@ class UserenaManager(UserManager):
         """
         Confirm an email address by checking a ``confirmation_key``.
 
-        A valid ``confirmation_key`` will set the newly wanted e-mail address
-        as the current e-mail address. Returns the user after success or
-        ``False`` when the confirmation key is invalid.
+        A valid ``confirmation_key`` will set the newly wanted e-mail
+        address as the current e-mail address. Returns the user after
+        success or ``False`` when the confirmation key is
+        invalid. Also sends the ``confirmation_complete`` signal.
 
         :param username:
             String containing the username of the user that wants their email
@@ -164,6 +165,7 @@ class UserenaManager(UserManager):
                 return False
             else:
                 user = userena.user
+                old_email = user.email
                 user.email = userena.email_unconfirmed
                 userena.email_unconfirmed, userena.email_confirmation_key = '',''
                 userena.save(using=self._db)
@@ -171,7 +173,8 @@ class UserenaManager(UserManager):
 
                 # Send the confirmation_complete signal
                 userena_signals.confirmation_complete.send(sender=None,
-                                                           user=user)
+                                                           user=user,
+                                                           old_email=old_email)
 
                 return user
         return False

--- a/userena/signals.py
+++ b/userena/signals.py
@@ -2,5 +2,5 @@ from django.dispatch import Signal
 
 signup_complete = Signal(providing_args=["user",])
 activation_complete = Signal(providing_args=["user",])
-confirmation_complete = Signal(providing_args=["user",])
+confirmation_complete = Signal(providing_args=["user","old_email"])
 password_complete = Signal(providing_args=["user",])


### PR DESCRIPTION
This is useful to confirmation_complete signal handlers that need to
update a mailing list subscription with the new address, for example.
