### PR TITLE
Added userena.views.signout with messages.success

### DIFF
--- a/userena/urls.py
+++ b/userena/urls.py
@@ -15,9 +15,7 @@ urlpatterns = patterns('',
        userena_views.signin,
        name='userena_signin'),
     url(r'^signout/$',
-       auth_views.logout,
-       {'next_page': userena_settings.USERENA_REDIRECT_ON_SIGNOUT,
-        'template_name': 'userena/signout.html'},
+       userena_views.signout,
        name='userena_signout'),
 
     # Reset password

--- a/userena/views.py
+++ b/userena/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import authenticate, login, logout, REDIRECT_FIELD_NAME
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.contrib.auth.views import logout as Signout
 from django.conf import settings
 from django.contrib import messages
 from django.utils.translation import ugettext as _
@@ -314,7 +315,25 @@ def signin(request, auth_form=AuthenticationForm,
                               template_name,
                               extra_context=extra_context)
 
+@secure_required
+def signout(request, next_page=userena_settings.USERENA_REDIRECT_ON_SIGNOUT, 
+            template_name='userena/signout.html', *args, **kwargs):
+    """
+    Signs out the user and adds a success message ``You have been signed
+    out.`` If next_page is defined you will be redirected to the URI. If
+    not the template in template_name is used.
 
+    :param next_page:
+        A string which specifies the URI to redirect to.
+
+    :param template_name:
+        String defining the name of the template to use. Defaults to
+        ``userena/signout.html``.
+
+    """
+    if request.user.is_authenticated() and userena_settings.USERENA_USE_MESSAGES:
+        messages.success(request, _('You have been signed out.'), fail_silently=True)
+    return Signout(request, next_page, template_name, *args, **kwargs)
 
 @secure_required
 @permission_required_or_403('change_user', (User, 'username', 'username'))


### PR DESCRIPTION
signin has a messages.success of 'You have been signed in.' 
signout should have a messages.success of 'You have been signed out.'

I have my USERENA_REDIRECT_ON_SIGNOUT = '/' and I use messages to inform the user. I actually have a section on my base.html between my menu section and content section that automatically displays the messages if there are any, which greatly simplifies my code. I think this is a pretty common usage.

After reviewing django.contrib.auth.views.logout I figured it was best to just check if the user was authenticated, USERENA_USE_MESSAGES was true, add the message.success and let django.contrib.auth.logout do its thing.

Great project. Like most things I started out with a lot of code and complication and ended up with something very simple. At this point it seems almost trivial, but it simplifies and unifies userena.urls a bit and address something I see as common usage without breaking anything.
