### PR TITLE
Invitation flow

### DIFF
--- a/userena/managers.py
+++ b/userena/managers.py
@@ -28,7 +28,7 @@ class UserenaManager(UserManager):
     """ Extra functionality for the Userena model. """
 
     def create_user(self, username, email, password, active=False,
-                    send_email=True):
+                    send_email=True, promoter=None, first_name=None):
         """
         A simple wrapper that creates a new :class:`User`.
 
@@ -50,6 +50,11 @@ class UserenaManager(UserManager):
             set this to ``False`` when you want to create a user in your own
             code, but don't want the user to activate through email.
 
+        :param promoter:
+            User who invites the new user, in this case password is None and
+            the email sent will be an invitation email rather than an activation
+            email.
+
         :return: :class:`User` instance representing the new user.
 
         """
@@ -57,6 +62,8 @@ class UserenaManager(UserManager):
 
         new_user = User.objects.create_user(username, email, password)
         new_user.is_active = active
+        if first_name:
+            new_user.first_name = first_name
         new_user.save()
 
         userena_profile = self.create_userena_profile(new_user)
@@ -78,7 +85,10 @@ class UserenaManager(UserManager):
             assign(perm[0], new_user, new_user)
 
         if send_email:
-            userena_profile.send_activation_email()
+            if promoter:
+                userena_profile.send_invite_email(promoter)
+            else:
+                userena_profile.send_activation_email()
  
         return new_user
 

--- a/userena/models.py
+++ b/userena/models.py
@@ -175,7 +175,7 @@ class UserenaSignup(models.Model):
         """
         Sends a activation email to the user.
 
-        This email is send when the user wants to activate their newly created
+        This email is sent when the user wants to activate their newly created
         user.
 
         """
@@ -191,6 +191,32 @@ class UserenaSignup(models.Model):
         subject = ''.join(subject.splitlines())
 
         message = render_to_string('userena/emails/activation_email_message.txt',
+                                   context)
+        send_mail(subject,
+                  message,
+                  settings.DEFAULT_FROM_EMAIL,
+                  [self.user.email,])
+
+    def send_invite_email(self, promoter):
+        """
+        Sends a invitation email to the user.
+
+        This email is sent when a user invites another user to to join.
+
+        """
+        context = {'user': self.user,
+                   'promoter': promoter,
+                   'without_usernames': userena_settings.USERENA_WITHOUT_USERNAMES,
+                   'protocol': get_protocol(),
+                   'activation_days': userena_settings.USERENA_ACTIVATION_DAYS,
+                   'activation_key': self.activation_key,
+                   'site': Site.objects.get_current()}
+
+        subject = render_to_string('userena/emails/invitation_email_subject.txt',
+                                   context)
+        subject = ''.join(subject.splitlines())
+
+        message = render_to_string('userena/emails/invitation_email_message.txt',
                                    context)
         send_mail(subject,
                   message,

--- a/userena/templates/userena/activate_invite.html
+++ b/userena/templates/userena/activate_invite.html
@@ -1,0 +1,27 @@
+{% extends 'userena/base_userena.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Activate your account." %}{% endblock %}
+{% block content_title %}<h2>{% trans "Pick a password and be on your way." %}</h2>{% endblock %}
+
+{% block content %}
+  <form action="" method="post">
+    {% csrf_token %}
+    <fieldset>
+      <legend>{% trans "Signup" %}</legend>
+      {{ form.non_field_errors }}
+      {% for field in form %}
+        {% if field.is_hidden %}
+	  {{field}}
+	{% else %}
+	  {{ field.errors }}
+	  <p>
+	    {{ field.label_tag }} 
+	    {{ field }}
+	  </p>
+	{% endif %}
+      {% endfor %}
+    </fieldset>
+    <input type="submit" value="{% trans "Signup"%}" />
+  </form>
+{% endblock %}

--- a/userena/templates/userena/activate_invite_fail.html
+++ b/userena/templates/userena/activate_invite_fail.html
@@ -1,0 +1,10 @@
+{% extends 'userena/base_userena.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "User already active." %}{% endblock %}
+{% block content_title %}<h2>{% trans "You are already an active user" %}</h2>{% endblock %}
+
+{% block content %}
+<p>{% trans "Your account could not be activated. This could be because your activation link has aged." %}</p>
+<p>{% trans "Please try signing up again or contact us if you think something went wrong." %}</p>
+{% endblock %}

--- a/userena/templates/userena/emails/invitation_email_message.txt
+++ b/userena/templates/userena/emails/invitation_email_message.txt
@@ -1,0 +1,12 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans with site.name as site %}Your friend {{promoter.first_name}} is using {{ site }} and invited you to join him.{% endblocktrans %}
+
+{% trans "To activate your account you should click on the link below:" %}
+
+{{ protocol }}://{{ site.domain }}{% url userena_activate_invite user.username activation_key %}
+
+{% trans "Thanks for using our site!" %}
+
+{% trans "Sincerely" %},
+{{ site.name }}
+{% endautoescape %}

--- a/userena/templates/userena/emails/invitation_email_subject.txt
+++ b/userena/templates/userena/emails/invitation_email_subject.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans with site.name as site %}{{ promoter.first_name }} invited you to join {{ site }}.{% endblocktrans %}

--- a/userena/urls.py
+++ b/userena/urls.py
@@ -49,6 +49,11 @@ urlpatterns = patterns('',
        userena_views.activate,
        name='userena_activate'),
 
+    # Activate invite
+    url(r'^(?P<username>[\.\w]+)/invite/(?P<activation_key>\w+)/$',
+       userena_views.activate_invite,
+       name='userena_activate_invite'),
+
     # Change email and confirm it
     url(r'^(?P<username>[\.\w]+)/email/$',
        userena_views.email_change,


### PR DESCRIPTION
This patch is not ready to be merged, but I wanted to put it out there to see if there is interest in offering an invitation flow in django-userena.

The patch allows existing users to invite a new user by entering their email address and optionally other user info like their first name. If no user with that email address exists a user is created so that it can be used for some basic interaction.

At the same time an activation email is sent out to the email address. It contains a link that allows the user to activate their account by entering a password. At this point no further email address validation is needed and the user is immediately signed in.

Cheers,
Felix
