### PR TITLE
Use the django-guardian permission_required_or_404 decorator for profile_detail view

### DIFF
--- a/userena/views.py
+++ b/userena/views.py
@@ -584,6 +584,7 @@ def profile_edit(request, username, edit_profile_form=EditProfileForm,
     extra_context['profile'] = profile
     return ExtraContextTemplateView.as_view(template_name=template_name,
                                             extra_context=extra_context)(request)
+@permission_required_or_403('change_profile', (get_profile_model(), 'user__username', 'username'))
 def profile_detail(
     request, username,
     template_name=userena_settings.USERENA_PROFILE_DETAIL_TEMPLATE,


### PR DESCRIPTION
Use the `permission_required_or_404` decorator to restrict access to the `profile_detail` view. There are actually checks inside the view to restrict access to profiles. But accessing your own profile while being not logged in does result in the string "You don't have permission to access the profile" being displayed and the user being forced to press the back button and login "manually".
Adding the decorator to the view leaves the possibility to redirect the user back to the login page by configuring django-guardian accordingly.
