### PR TITLE
BUGFIX: Signin form initialization.

### DIFF
--- a/userena/views.py
+++ b/userena/views.py
@@ -321,7 +321,7 @@ def signin(request, auth_form=AuthenticationForm,
         Form used for authentication supplied by ``auth_form``.
 
     """
-    form = auth_form
+    form = auth_form()
 
     if request.method == 'POST':
         form = auth_form(request.POST, request.FILES)


### PR DESCRIPTION
It's hard to realized this issue when using Django default templating system as it's too nice to tell the error. However, if you use Jinja2 you will get error in signin form.

I believe it was a typo as other forms in views are okay.

Credit goes to Fuhong Liu for locating this bug. Initially we had a fix in template but later Fuhong Liu found that it should have been fixed in the views.
