### PR TITLE
Sending mail to old email addresses if they exist

### DIFF
--- a/userena/models.py
+++ b/userena/models.py
@@ -125,18 +125,18 @@ class UserenaSignup(models.Model):
                   'site': Site.objects.get_current()}
 
 
-        # Email to the old address
+        # Email to the old address, if present
         subject_old = render_to_string('userena/emails/confirmation_email_subject_old.txt',
                                        context)
         subject_old = ''.join(subject_old.splitlines())
 
         message_old = render_to_string('userena/emails/confirmation_email_message_old.txt',
                                        context)
-
-        send_mail(subject_old,
-                  message_old,
-                  settings.DEFAULT_FROM_EMAIL,
-                  [self.user.email])
+        if self.user.email:
+            send_mail(subject_old,
+                      message_old,
+                      settings.DEFAULT_FROM_EMAIL,
+                    [self.user.email])
 
         # Email to the new address
         subject_new = render_to_string('userena/emails/confirmation_email_subject_new.txt',


### PR DESCRIPTION
Hi,

Recently I came across an issue when migrating to Userena in an existing project. In this project we had over a few thousand users without an email address. 

The ability to change your e-mail address using Userena, however, was failing because Userena attempts to send an email to the old email address. Yet in this use case there are no old email addresses, (more specifially, user.email is an empty unicode string), and our server returned SMTPRecipientsRefused errors.  

I made a quick fix by wrapping the send_mail function on line 135 of models.py in an if statement. Only when an old email address exists does it attempt to send a mail.

This was a quick solution for us and I can image that this will become a valid use-case as more and more people may incorporate Userena into their (existing) projects.

Kind regards,
Aksel
