### PR TITLE
Public or Private Message in Umessage

### DIFF
--- a/userena/contrib/umessages/admin.py
+++ b/userena/contrib/umessages/admin.py
@@ -18,7 +18,7 @@ class MessageAdmin(admin.ModelAdmin):
     fieldsets = (
         (None, {
             'fields': (
-                'sender', 'body',
+                'sender', 'body', 'public',
             ),
             'classes': ('monospace' ),
         }),
@@ -29,7 +29,7 @@ class MessageAdmin(admin.ModelAdmin):
             'classes': ('collapse', 'wide'),
         }),
     )
-    list_display = ('sender', 'body', 'sent_at')
+    list_display = ('sender', 'body', 'public', 'sent_at')
     list_filter = ('sent_at', 'sender')
     search_fields = ('body',)
 

--- a/userena/contrib/umessages/forms.py
+++ b/userena/contrib/umessages/forms.py
@@ -11,6 +11,8 @@ class ComposeForm(forms.Form):
     body = forms.CharField(label=_("Message"),
                            widget=forms.Textarea({'class': 'message'}),
                            required=True)
+    public = forms.BooleanField(label=_("Public"),
+                                required=False)
 
     def save(self, sender):
         """
@@ -27,9 +29,11 @@ class ComposeForm(forms.Form):
         """
         to_user_list = self.cleaned_data['to']
         body = self.cleaned_data['body']
+        public = self.cleaned_data['public']
 
         msg = Message.objects.send_message(sender,
                                            to_user_list,
-                                           body)
+                                           body,
+                                           public)
 
         return msg

--- a/userena/contrib/umessages/managers.py
+++ b/userena/contrib/umessages/managers.py
@@ -56,7 +56,7 @@ class MessageContactManager(models.Manager):
 class MessageManager(models.Manager):
     """ Manager for the :class:`Message` model. """
 
-    def send_message(self, sender, to_user_list, body):
+    def send_message(self, sender, to_user_list, body, public):
         """
         Send a message from a user, to a user.
 
@@ -66,12 +66,16 @@ class MessageManager(models.Manager):
         :param to_user_list:
             A list which elements are :class:`User` to whom the message is for.
 
-        :param message:
+        :param body:
             String containing the message.
+
+        :param public:
+            Boolean value indicate if the message is public or public.
 
         """
         msg = self.model(sender=sender,
-                         body=body)
+                         body=body,
+                         public=public)
         msg.save()
 
         # Save the recipients
@@ -86,6 +90,12 @@ class MessageManager(models.Manager):
                                  sender_deleted_at__isnull=True) |
                                Q(sender=to_user, recipients=from_user,
                                  messagerecipient__deleted_at__isnull=True))
+        return messages
+
+    def get_public_messages(self, to_user):
+        """ Returns a list of public messages sent to a user """
+        messages = self.filter(recipients=to_user, public=True, 
+                                sender_deleted_at__isnull=True)
         return messages
 
 class MessageRecipientManager(models.Manager):

--- a/userena/contrib/umessages/models.py
+++ b/userena/contrib/umessages/models.py
@@ -105,6 +105,8 @@ class Message(models.Model):
                                              null=True,
                                              blank=True)
 
+    public = models.BooleanField(default=True)
+
     objects = MessageManager()
 
     class Meta:


### PR DESCRIPTION
Hi,
I made some improvements in umessages. Now a message can be public or private. And I also added a function in manager to retrieve all public messages to a user. This would be useful when one wants to display a user's public messages.
