### PR TITLE
Create all permission when running migrate.

### DIFF
--- a/userena/models.py
+++ b/userena/models.py
@@ -10,15 +10,14 @@ from django.utils.translation import ugettext_lazy as _
 from easy_thumbnails.fields import ThumbnailerImageField
 from guardian.shortcuts import get_perms
 from userena import settings as userena_settings
-from userena.managers import UserenaManager, UserenaBaseProfileManager
+from userena.managers import UserenaManager, UserenaBaseProfileManager, \
+    ASSIGNED_PERMISSIONS
 from userena.utils import get_gravatar, generate_sha1, get_protocol, \
     get_datetime_now
 import datetime
 
 
-PROFILE_PERMISSIONS = (
-            ('view_profile', 'Can view profile'),
-)
+PROFILE_PERMISSIONS = ASSIGNED_PERMISSIONS['profile']
 
 
 def upload_to_mugshot(instance, filename):


### PR DESCRIPTION
When running migrate or syncdb only the permission 'view_profile' gets created because in models.py this is the only permission that is present in the 'permissions' attribute of META. 

By using the permissions that are defined in managers.py all necessary permissions should be created. 

I'd like to add a test but sadly i haven't been able to run the testsuite (See Issue #253).
