### PR TITLE
Default to hashlib instead of django.utils.hashcompat

### DIFF
--- a/userena/forms.py
+++ b/userena/forms.py
@@ -2,7 +2,11 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
-from django.utils.hashcompat import sha_constructor
+
+try:
+    from hashlib import sha1 as sha_constructor
+except ImportError:
+    from django.utils.hashcompat import sha_constructor
 
 from userena import settings as userena_settings
 from userena.models import UserenaSignup

--- a/userena/utils.py
+++ b/userena/utils.py
@@ -1,13 +1,16 @@
 from django.conf import settings
-from django.utils.hashcompat import sha_constructor
 from django.contrib.auth.models import SiteProfileNotAvailable
 from django.db.models import get_model
+
+try:
+    from hashlib import sha1 as sha_constructor, md5 as md5_constructor
+except ImportError:
+    from django.utils.hashcompat import sha_constructor, md5_constructor
 
 from userena import settings as userena_settings
 
 import urllib, random, datetime
 
-from django.utils.hashcompat import md5_constructor
 
 def get_gravatar(email, size=80, default='identicon'):
     """ Get's a Gravatar for a email address.


### PR DESCRIPTION
django.utils.hashcompat is deprecated and removed in Django 1.5.
Use sha1 and md5 from the hashlib module in the Python standard library.

django.utils.hashcompat will still be used as a fallback if the installed
Python version does not support hashlib.
