### PR TITLE
Fix upload_to_mugshot attr calls on user instance

### DIFF
--- a/userena/models.py
+++ b/userena/models.py
@@ -31,9 +31,9 @@ def upload_to_mugshot(instance, filename):
     extension = filename.split('.')[-1].lower()
     salt, hash = generate_sha1(instance.id)
     path = userena_settings.USERENA_MUGSHOT_PATH % {
-                                                     'username': instance.user.username,
-                                                     'id': instance.user.id,
-                                                     'date': instance.user.date_joined,
+                                                     'username': instance.username,
+                                                     'id': instance.id,
+                                                     'date': instance.date_joined,
                                                      'date_now': get_datetime_now().date(),
                                                      }
     return '%(path)s%(hash)s.%(extension)s' % {'path': path,


### PR DESCRIPTION
Code in upload_to_mugshot is calling a user
property on an instance of a user causing an
error and failing unit test.
## ERROR: test_upload_mugshot (userena.tests.models.UserenaSignupModelTests)

Traceback (most recent call last):
  File "/Users/michael/Projects/opensource/django-userena/four/lib/python2.7/site-packages/django_userena-1.1.2-py2.7.egg/userena/models.py", line 34, in upload_to_mugshot
    'username': instance.user.username,
AttributeError: 'User' object has no attribute 'user'
