### PR TITLE
Full locale middleware path in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -171,7 +171,7 @@ must also connect itself to the :class:`User` model of Django.
                                            max_length=5)
 
 If you want the user have the ability to choose their default language in their
-profile, you must add ``UserenaLocaleMiddleware`` at the end of
+profile, you must add ``userena.middleware.UserenaLocaleMiddleware`` at the end of
 ``MIDDLEWARE_CLASSES`` in your Django settings. This does require a profile
 model which has a language field. You can use the
 ``UserenaLanguageBaseProfile`` class of userena that does this for you.


### PR DESCRIPTION
Just putting `UserenaLocaleMiddleware` in `settings.py` results in an error:

```
ImproperlyConfigured: UserenaLocaleMiddleware isn't a middleware module
```

I probably won't be the last person to just copy-and-paste from `installation.rst` and have to spend a few moments figuring out what to do (the [UserenaLocaleMiddleware docs](http://docs.django-userena.org/en/latest/api/middleware.html) are unfortunately blank to the extent that the actual import path isn't shown).
