### PR TITLE
EditProfileForm forces ordering of and overwrites fields

### DIFF
--- a/userena/forms.py
+++ b/userena/forms.py
@@ -222,14 +222,6 @@ class EditProfileForm(forms.ModelForm):
                                 max_length=30,
                                 required=False)
 
-    def __init__(self, *args, **kw):
-        super(EditProfileForm, self).__init__(*args, **kw)
-        # Put the first and last name at the top
-        new_order = self.fields.keyOrder[:-2]
-        new_order.insert(0, 'first_name')
-        new_order.insert(1, 'last_name')
-        self.fields.keyOrder = new_order
-
     class Meta:
         model = get_profile_model()
         exclude = ['user']


### PR DESCRIPTION
The code assumes 'first_name' and 'last_name' will always be the last two fields
in the form. This assumption is incorrect if additional fields are added to the
form ::

```
class CustomProfileForm(EditProfileForm):
    extra_info = forms.CharField(label='Extra Info')
    more_extra_info = forms.CharField(label='Extra Info')
```

or if the fields are explicitly ordered ::

```
class CustomProfileForm(EditProfileForm):
    class Meta(EditProfileForm.Meta):
        fields = ('first_name', 'last_name', 'mugshot', 'privacy')
```

Both produce additional first_name/last_name pairs in the rendered form, and in
the latter case they overwrite mugshot and privacy.

It seems best to leave the ordering up to Meta.fields.
https://docs.djangoproject.com/en/dev/topics/forms/modelforms/#changing-the-order-of-fields
