### PR TITLE
Add missing permissions

### DIFF
--- a/userena/models.py
+++ b/userena/models.py
@@ -18,7 +18,10 @@ import datetime
 
 PROFILE_PERMISSIONS = (
             ('view_profile', 'Can view profile'),
-)
+            ('change_profile', 'Can change profile'),
+            ('delete_profile', 'Can delete profile'),
+            ('add_profile', 'Can add profile'),
+) 
 
 
 def upload_to_mugshot(instance, filename):


### PR DESCRIPTION
The error described in many issues and the 1st one of the [FAQ](https://django-userena.readthedocs.org/en/latest/faq.html?highlight=FAQ) page is caused by the missing custom permissions in the userena/models.py files. 

While the documentation under UserenaBaseProfile.Meta says:
_We also define custom permissions because we don't know how the model that extends this one is going to be called. So we don't know what permissions to check. For ex. if the user defines a profile model that is called `MyProfile`, than the permissions would be `add_myprofile` etc. We want to be able to always check `add_profile`, `change_profile` etc._, the only custom permission defined is "view_profile" the other 3 default permisssions (add, change and delete) are not. 

So, I just added them.

Probably this will eliminate the need for the check_permissions command, but I did not dig deeper to check it out, so I did not touch it.
