### PR TITLE
Patch to fix the issue that comes with registering Custom User Model through Userena.

### DIFF
--- a/userena/admin.py
+++ b/userena/admin.py
@@ -1,10 +1,8 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from django.utils.translation import ugettext as _
 from guardian.admin import GuardedModelAdmin
 
 from userena.models import UserenaSignup
-from userena.utils import get_profile_model, get_user_model
 
 class UserenaSignupInline(admin.StackedInline):
     model = UserenaSignup
@@ -15,7 +13,3 @@ class UserenaAdmin(UserAdmin, GuardedModelAdmin):
     list_display = ('username', 'email', 'first_name', 'last_name',
                     'is_staff', 'is_active', 'date_joined')
     list_filter = ('is_staff', 'is_superuser', 'is_active')
-
-admin.site.unregister(get_user_model())
-admin.site.register(get_user_model(), UserenaAdmin)
-admin.site.register(get_profile_model())


### PR DESCRIPTION
While registering the user model through userena, it requires to have multiple fields which are there in "auth.User". For someone using "Custom User", this may give error for various fields as it uses UserAdmin. 

One of such fields being 'username'. For someone using the custom User model, this field may not be present in the model, but userena presently makes it mandatory to have this field. This happens in the admin.py where we register the Custom User model using the UserAdmin, which in turn assumes the Custom User model to have fields like 'username', 'groups' etc. Furthermore, registering the user model can be left to the developer.

PS: All this happening when the Custom User is using "django.contrib.auth.models.AbstractBaseUser".
