### PR TITLE
Use protocol-relative url for gravatar

### DIFF
--- a/userena/utils.py
+++ b/userena/utils.py
@@ -46,7 +46,7 @@ def get_gravatar(email, size=80, default='identicon'):
     """
     if userena_settings.USERENA_MUGSHOT_GRAVATAR_SECURE:
         base_url = 'https://secure.gravatar.com/avatar/'
-    else: base_url = 'http://www.gravatar.com/avatar/'
+    else: base_url = '//www.gravatar.com/avatar/'
 
     gravatar_url = '%(base_url)s%(gravatar_id)s?' % \
             {'base_url': base_url,


### PR DESCRIPTION
I think this is better because if a site uses both HTTP and HTTPS than you can't really use `USERENA_MUGSHOT_GRAVATAR_SECURE`.
