### PR TITLE
Update utils.py

### DIFF
--- a/userena/utils.py
+++ b/userena/utils.py
@@ -114,7 +114,7 @@ def get_profile_model():
            (not settings.AUTH_PROFILE_MODULE):
         raise SiteProfileNotAvailable
 
-    profile_mod = get_model(*settings.AUTH_PROFILE_MODULE.split('.'))
+    profile_mod = get_model(*settings.AUTH_PROFILE_MODULE.rsplit('.',1))
     if profile_mod is None:
         raise SiteProfileNotAvailable
     return profile_mod


### PR DESCRIPTION
Previously the herein referenced AUTH_PROFILE_MODULE could not point to a model for a subpackaged app because this get_profile_model function splits on all periods. As we know get_model takes app_label and model as arguments so for a subpackaged app this would break as it will send 3+ arguments. This adjustment to use rsplit with a maxlimit instead of split correctly interprets the app_label and model by splitting on the last period in the string.
