### PR TITLE
Fix user creation for utf-8 usernames

### DIFF
--- a/userena/utils.py
+++ b/userena/utils.py
@@ -108,9 +108,11 @@ def generate_sha1(string, salt=None):
     """
     if not isinstance(string, (str, unicode)):
         string = str(string)
+    if isinstance(string, unicode):
+        string = string.encode("utf-8")
     if not salt:
         salt = sha_constructor(str(random.random())).hexdigest()[:5]
-    hash = sha_constructor(salt+str(string.encode('utf-8'))).hexdigest()
+    hash = sha_constructor(salt+string).hexdigest()
 
     return (salt, hash)
 


### PR DESCRIPTION
The sha1 generated by the generate_sha1 function choked on utf8 strings.
