### PR TITLE
register Profile using a GuardedModelAdmin

### DIFF
--- a/userena/admin.py
+++ b/userena/admin.py
@@ -27,4 +27,4 @@ if userena_settings.USERENA_REGISTER_USER:
     admin.site.register(get_user_model(), UserenaAdmin)
     
 if userena_settings.USERENA_REGISTER_PROFILE:    
-    admin.site.register(get_profile_model())
+    admin.site.register(get_profile_model(), GuardedModelAdmin)


### PR DESCRIPTION
when registering the profile use a GuardedModelAdmin so that the guardian object permissions can be set in the in the admin.

This fixes issue #395, which I opened, for me.
