### PR TITLE
Django v1.7+ doesn't provide SiteProfileNotAvailable exception anymore.

### DIFF
--- a/userena/middleware.py
+++ b/userena/middleware.py
@@ -1,7 +1,12 @@
 from django.utils import translation
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
-from django.contrib.auth.models import SiteProfileNotAvailable
+
+try:
+    from django.contrib.auth.models import SiteProfileNotAvailable
+except ImportError:
+    class SiteProfileNotAvailable(Exception):
+        pass
 
 from userena import settings as userena_settings
 

--- a/userena/utils.py
+++ b/userena/utils.py
@@ -1,6 +1,11 @@
 from django.conf import settings
-from django.contrib.auth.models import SiteProfileNotAvailable
 from django.db.models import get_model
+
+try:
+    from django.contrib.auth.models import SiteProfileNotAvailable
+except ImportError:
+    class SiteProfileNotAvailable(Exception):
+        pass
 
 try:
     from hashlib import sha1 as sha_constructor, md5 as md5_constructor


### PR DESCRIPTION
In the latest version of Django SiteProfileNotAvailable exception doesn't exist anymore.
