### PR TITLE
Fix #493 - html email template should be also used for password reset

### DIFF
--- a/userena/compat.py
+++ b/userena/compat.py
@@ -22,6 +22,11 @@ if django.VERSION >= (1, 6, 0):  # pragma: no cover
     auth_views_compat_quirks['userena_password_reset_confirm'] = {
         'post_reset_redirect': 'userena_password_reset_complete',
     }
+if django.VERSION >= (1, 7, 0):
+    # Django 1.7 added a new argument to django.contrib.auth.views.password_reset
+    # called html_email_template_name which allows us to pass it the html version
+    # of the email
+    auth_views_compat_quirks['html_email_template_name'] = 'userena/emails/password_reset_message.html'
 
 
 # below are backward compatibility fixes


### PR DESCRIPTION
Since Django 1.7 we have the option of passing html email template. Let's use it.