### PR TITLE
Tox: Install Django 1.4.x from source

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,12 @@ basepython =
 
 commands={envpython} userena/runtests/runtests.py userena umessages
 
+[testenv:py27-django14]
+install_command = pip install --no-binary=Django {opts} {packages}
+
+[testenv:py26-django14]
+install_command = pip install --no-binary=Django {opts} {packages}
+
 [testenv:coverage]
 basepython = python2.7
 


### PR DESCRIPTION
Recent versions of pip (7.x+) default to creating and using .whl packages.
In the case of Django 1.4 this installs the templates to the root of a
virtualenv, rather than '.../site-packages/django/...'.

So when userna's tests are run inside Tox any that use templates fail with

    TemplateDoesNotExist: registration/password_reset_subject.txt

installing Django 1.4 from source fixes this.