### PR TITLE
Signin view should have argument for inactive url redirect

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ usedevelop = True
 deps =
     django{15,16}: south
     django{15,16}: django-guardian<1.4.0
+    django{15,16}: unittest2
     django15: django==1.5.12
     django16: django==1.6.11
     django17: django==1.7.11

--- a/userena/tests/tests_views.py
+++ b/userena/tests/tests_views.py
@@ -2,16 +2,32 @@ import re
 
 from datetime import datetime, timedelta
 from django.contrib.auth import get_user_model
+from django.conf.urls import url
 from django.core.urlresolvers import reverse
 from django.core import mail
 from django.contrib.auth.forms import PasswordChangeForm
+from django.views.generic import TemplateView
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from userena import forms
+from userena import views as userena_views
 from userena import settings as userena_settings
 from userena.utils import get_user_profile
 
 User = get_user_model()
+
+
+class SigninInactiveURLs(object):
+    """ Override default signin urls to test inactive redirect """
+    urlpatterns = [
+        url(r'^signup/$',userena_views.signin,
+            {'inactive_url': '/disabled/'},
+            name='custom_signin'),
+        url(r'^disabled/$',
+            TemplateView.as_view(template_name='userena/disabled.html'),
+            name='custom_disabled')
+    ]
 
 
 class UserenaViewsTests(TestCase):
@@ -292,6 +308,19 @@ class UserenaViewsTests(TestCase):
         self.assertRedirects(response,
                              reverse('userena_disabled',
                                      kwargs={'username': user.username}))
+
+    @override_settings(ROOT_URLCONF=SigninInactiveURLs)
+    def test_signin_view_inactive_redirect_specified(self):
+        """ A ``POST`` from a inactive user with inactive url specified """
+        user = User.objects.get(email='john@example.com')
+        user.is_active = False
+        user.save()
+
+        response = self.client.post(reverse('custom_signin'),
+                                    data={'identification': 'john@example.com',
+                                          'password': 'blowfish'})
+
+        self.assertRedirects(response, reverse('custom_disabled'))
 
     def test_signin_view_success(self):
         """

--- a/userena/tests/tests_views.py
+++ b/userena/tests/tests_views.py
@@ -1,6 +1,13 @@
 import re
+import sys
+if sys.version_info < (2, 7):
+    # unittest2 for backport compatibility
+    from unittest2 import skipIf
+else:
+    from unittest import skipIf
 
 from datetime import datetime, timedelta
+import django
 from django.contrib.auth import get_user_model
 from django.conf.urls import url
 from django.core.urlresolvers import reverse
@@ -309,6 +316,7 @@ class UserenaViewsTests(TestCase):
                              reverse('userena_disabled',
                                      kwargs={'username': user.username}))
 
+    @skipIf(django.VERSION < (1, 7, 0), "override `ROOT_URLCONF` not supported")
     @override_settings(ROOT_URLCONF=SigninInactiveURLs)
     def test_signin_view_inactive_redirect_specified(self):
         """ A ``POST`` from a inactive user with inactive url specified """

--- a/userena/views.py
+++ b/userena/views.py
@@ -357,7 +357,7 @@ def disabled_account(request, username, template_name, extra_context=None):
 
     :param template_name:
         String defining the name of the template to use. Defaults to
-        ``userena/signup_complete.html``.
+        ``userena/disabled.html``.
 
     **Keyword arguments**
 

--- a/userena/views.py
+++ b/userena/views.py
@@ -390,7 +390,8 @@ def disabled_account(request, username, template_name, extra_context=None):
 def signin(request, auth_form=AuthenticationForm,
            template_name='userena/signin_form.html',
            redirect_field_name=REDIRECT_FIELD_NAME,
-           redirect_signin_function=signin_redirect, extra_context=None):
+           redirect_signin_function=signin_redirect,
+           inactive_url=None, extra_context=None):
     """
     Signin using email or username with password.
 
@@ -420,6 +421,10 @@ def signin(request, auth_form=AuthenticationForm,
         Function which handles the redirect. This functions gets the value of
         ``REDIRECT_FIELD_NAME`` and the :class:`User` who has logged in. It
         must return a string which specifies the URI to redirect to.
+
+    :param inactive_url:
+        Named URL which will be passed on to a django ``reverse`` function if
+        account is disabled. Defaults to the ``userena_disabled`` url.
 
     :param extra_context:
         A dictionary containing extra variables that should be passed to the
@@ -459,8 +464,10 @@ def signin(request, auth_form=AuthenticationForm,
                                     request.POST.get(redirect_field_name)), user)
                 return HttpResponseRedirect(redirect_to)
             else:
-                return redirect(reverse('userena_disabled',
-                                        kwargs={'username': user.username}))
+                if inactive_url: redirect_to = inactive_url
+                else: redirect_to = reverse('userena_disabled',
+                                            kwargs={'username': user.username})
+                return redirect(redirect_to)
 
     if not extra_context: extra_context = dict()
     extra_context.update({


### PR DESCRIPTION
After login successfully, there's no way to specify redirect url if account is disabled. It's hardcoded with url resolved from name `userena_disabled` and arguments `username`. 

What if application doesn't want to include `username`  in url and just return a static template. All the usage of `redirect` in views have option for that except this usecase 