### PR TITLE
fix/554 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ account management. It's a fully customizable application that takes care of
 the signup, activation, messaging and more. It's BSD licensed, which means you
 can use it commercially for free!
 
-## [Documentation](http://docs.django-userena.org/en/latest/index.html)
+## [Documentation](https://django-userena.readthedocs.io/en/latest/index.html)
 
 Complete documentation about the
-[installation](http://docs.django-userena.org/en/latest/installation.html),
-[settings](http://docs.django-userena.org/en/latest/settings.html) and
-[F.A.Q.](http://docs.django-userena.org/en/latest/faq.html) is available on
-[Read the Docs](http://docs.django-userena.org/en/latest/index.html).
+[installation](https://django-userena.readthedocs.io/en/latest/installation.html),
+[settings](https://django-userena.readthedocs.io/en/latest/settings.html) and
+[F.A.Q.](https://django-userena.readthedocs.io/en/latest/faq.html) is available on
+[Read the Docs](https://django-userena.readthedocs.io/en/latest/index.html).
 
 For list of updates and changes see `UPDATES.md` file.

--- a/demo/demo/templates/static/promo.html
+++ b/demo/demo/templates/static/promo.html
@@ -70,7 +70,7 @@
   <a href="https://github.com/bread-and-pepper/django-userena/downloads" id="download">Download</a>
   </li>
   <li><h3>Read docs</h3>
-  <a href="http://docs.django-userena.org/" id="docs">Documentation</a>
+  <a href="https://django-userena.readthedocs.io/" id="docs">Documentation</a>
   </li>
   <li><h3>Try it out!</h3>
   <a href="{% url 'userena_signup' %}" id="demo">Try it out!</a>

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -15,7 +15,7 @@ I get a "``Site matching query does not exist.``" exception
 -----------------------------------------------------------
 
 This means that your settings.SITE_ID value is incorrect. See the instructions
-on SITE_ID in the [Installation section](http://docs.django-userena.org/en/latest/installation.html).
+on SITE_ID in the [Installation section](https://django-userena.readthedocs.io/en/latest/installation.html).
 
 
 <ProfileModel> is already registered exception
@@ -29,12 +29,12 @@ follows:
 
     # Unregister userena's
     admin.site.unregister(YOUR_PROFILE_MODEL)
-                
+
     # Register your own admin class and attach it to the model
     admin.site.register(YOUR_PROFILE_MODEL, YOUR_PROFILE_ADMIN)
 
 Can I still add users manually?
--------------------------------           
+-------------------------------
 Yes, but Userena requires there to be a `UserenaSignup` object for every
 registered user. If it's not there, you could receive the following error:
 


### PR DESCRIPTION
Update to change hijacked link of http://docs.django-userena.org to the correct and secure https://django-userena.readthedocs.io